### PR TITLE
Implemented encode8Bit and decode8Bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ vlq.decode( '2H' ); // [ 123 ]
 vlq.decode( '2HwcqxB' ); // [ 123, 456, 789 ]
 ```
 
+### Encoding in 8-bit
+
+`vlq.encode8Bit` accepts an integer and returns a Buffer
+
+```js
+vlq.encode8Bit( 0x7f ); // <Buffer 7f>
+vlq.encode8Bit( 0x80 ); // <Buffer 81 00>
+vlq.encode8Bit( 0x2000 ); // <Buffer c0 00>
+```
+
+### Decoding in 8-bit
+
+`vlq.decode8Bit` accepts a buffer or an array of octets and returns an integer 
+
+```js
+vlq.decode8Bit( [0x7f] ); // 0x7f
+vlq.decode8Bit( [0x81, 0] ); // 0x80
+vlq.decode8Bit( [0xc0, 0] ); // 0x2000
+```
 
 ## Using vlq.js with sourcemaps
 

--- a/dist/vlq.js
+++ b/dist/vlq.js
@@ -6,6 +6,8 @@
 
 	exports.decode = decode;
 	exports.encode = encode;
+	exports.decode8Bit = decode8Bit;
+	exports.encode8Bit = encode8Bit;
 
 	var charToInteger = {};
 	var integerToChar = {};
@@ -89,6 +91,38 @@
 		} while ( num > 0 );
 
 		return result;
+	}
+
+	function encode8Bit ( num ) {
+		var arr = [], i;
+
+		// Break up num into groups of 7-bit values
+		while (num) {
+		    arr.unshift(num & (127));
+		    num >>= 7;
+		}
+
+		// Flip MSB of all 7-bit values except the last one
+		for ( i = 0; i < arr.length - 1; i += 1 ) {
+			arr[i] += 128;
+		}
+
+		return new Buffer(arr);
+	}
+
+	function decode8Bit ( buffer ) {
+		var num = 0, i;
+
+		if (!Buffer.isBuffer(buffer)) {
+			buffer = new Buffer(buffer);
+		}
+
+		for ( i = 0; i < buffer.length - 1; i += 1) {
+			num += buffer[i] - 128;
+			num <<= 7;
+		}
+
+		return num + buffer[buffer.length - 1];
 	}
 
 }));

--- a/src/vlq.js
+++ b/src/vlq.js
@@ -81,3 +81,35 @@ function encodeInteger ( num ) {
 
 	return result;
 }
+
+export function encode8Bit ( num ) {
+	var arr = [], i;
+
+	// Break up num into groups of 7-bit values
+	while (num) {
+	    arr.unshift(num & (127));
+	    num >>= 7;
+	}
+
+	// Flip MSB of all 7-bit values except the last one
+	for ( i = 0; i < arr.length - 1; i += 1 ) {
+		arr[i] += 128;
+	}
+
+	return new Buffer(arr);
+}
+
+export function decode8Bit ( buffer ) {
+	var num = 0, i;
+
+	if (!Buffer.isBuffer(buffer)) {
+		buffer = new Buffer(buffer);
+	}
+
+	for ( i = 0; i < buffer.length - 1; i += 1) {
+		num += buffer[i] - 128;
+		num <<= 7;
+	}
+
+	return num + buffer[buffer.length - 1];
+}

--- a/test/decode8Bit.js
+++ b/test/decode8Bit.js
@@ -1,0 +1,17 @@
+var assert = require( 'assert' ),
+	vlq = require( '../' );
+
+var tests = [
+	[ [0x40], 0x40 ],
+	[ [0x7f], 0x7f ],
+	[ [0x81, 0], 0x80 ],
+	[ [0xc0, 0], 0x2000 ],
+	[ [0xff, 0x7f], 0x3fff ],
+	[ [0x81, 0x80, 0], 0x4000 ]
+];
+
+tests.forEach( function ( test ) {
+	assert.equal( vlq.decode8Bit( test[0] ), test[1] );
+});
+
+console.log( 'all vlq.decode8Bit tests passed' );

--- a/test/encode8Bit.js
+++ b/test/encode8Bit.js
@@ -1,0 +1,17 @@
+var assert = require( 'assert' ),
+	vlq = require( '../' );
+
+var tests = [
+	[ 0x40, '40' ],
+	[ 0x7f, '7f' ],
+	[ 0x80, '8100' ],
+	[ 0x2000, 'c000' ],
+	[ 0x3fff, 'ff7f' ],
+	[ 0x4000, '818000' ]
+];
+
+tests.forEach( function ( test ) {
+	assert.equal( vlq.encode8Bit( test[0] ).toString('hex'), test[1] );
+});
+
+console.log( 'all vlq.encode8Bit tests passed' );

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,4 @@
 require( './encode' );
 require( './decode' );
+require( './encode8Bit' );
+require( './decode8Bit' );


### PR DESCRIPTION
I'm working on a project that involves outputting MIDI data, which uses variable length quantities encoded in 8-bit chunks (as opposed to 6).  Since the output is binary, it made sense to create a function that takes a number, turns it into a VLQ, and returns a buffer.  I implemented this for my own project, but I figured it would make a good addition to your VLQ library, so I went ahead and added it.