### PR TITLE
Handle overflow cases

### DIFF
--- a/src/vlq.ts
+++ b/src/vlq.ts
@@ -27,9 +27,13 @@ export function decode ( string: string ): number[] {
 			shift += 5;
 		} else {
 			const shouldNegate = value & 1;
-			value >>= 1;
+			value >>>= 1;
 
-			result.push( shouldNegate ? -value : value );
+			if (shouldNegate) {
+				result.push( value === 0 ? -0x80000000 : -value );
+			} else {
+				result.push(value);
+			}
 
 			// reset
 			value = shift = 0;
@@ -65,7 +69,7 @@ function encodeInteger ( num: number ): string {
 
 	do {
 		let clamped = num & 31;
-		num >>= 5;
+		num >>>= 5;
 
 		if ( num > 0 ) {
 			clamped |= 32;

--- a/test/decode.js
+++ b/test/decode.js
@@ -3,7 +3,10 @@ var assert = require( 'assert' ),
 
 var tests = [
 	[ 'AAAA', [ 0, 0, 0, 0 ] ],
-	[ 'AAgBC', [ 0, 0, 16, 1 ] ]
+	[ 'AAgBC', [ 0, 0, 16, 1 ] ],
+	[ 'D', [ -1 ] ],
+	[ 'B', [ -2147483648 ] ],
+	[ '+/////D', [ 2147483647 ] ]
 ];
 
 tests.forEach( function ( test ) {

--- a/test/encode.js
+++ b/test/encode.js
@@ -3,7 +3,10 @@ var assert = require( 'assert' ),
 
 var tests = [
 	[ [ 0, 0, 0, 0 ], 'AAAA' ],
-	[ [ 0, 0, 16, 1 ], 'AAgBC' ]
+	[ [ 0, 0, 16, 1 ], 'AAgBC' ],
+	[ [ -1 ], 'D' ],
+	[ [ -2147483648 ], 'B' ],
+	[ [ 2147483647 ], '+/////D' ]
 ];
 
 tests.forEach( function ( test ) {


### PR DESCRIPTION
There were overflow cases hidden in the encode and decode:

1. Encoding
   - Any number with the 31st bit set would be incorrect, because it used `>>` instead of `>>>`. So the 31st bit would be set to the 32nd (sign bit, making it negative). Then when we try to encode the number, we would that it's `num < 0` after the first iteration.
2. Decoding
   - The encoded representation of -2147483648 (smallest 32bit signed int) would return -0
   - Any number with the 31st bit set would return the opposite sign, because it used `>>` instead of `>>>`.
