### PR TITLE
fix(package): support ts's newer moduleResolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
+			"types": "./types/index.d.ts",
 			"import": "./src/index.js",
 			"require": "./dist/index.cjs"
 		}


### PR DESCRIPTION
add support for typescript-based consumer projects with `"moduleResolution": "node16"` or `"moduleResolution": "bundler"`. In those cases typescript loads the "types" condition of the specific subpath export and ignores the root one (the one outside the "exports").